### PR TITLE
Allow building on GHC 7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Taken from https://github.com/hvr/multi-ghc-travis
 
 env:
+ - CABALVER=1.18 GHCVER=7.6.3
  - CABALVER=1.18 GHCVER=7.8.4
  - CABALVER=1.22 GHCVER=7.10.1
 

--- a/should-not-typecheck.cabal
+++ b/should-not-typecheck.cabal
@@ -19,7 +19,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Test.ShouldNotTypecheck
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.6 && < 5
                      , HUnit >= 1.2
   default-language:    Haskell2010
 

--- a/test/ShouldNotTypecheckSpec.hs
+++ b/test/ShouldNotTypecheckSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE PatternSynonyms #-}
 {-# OPTIONS_GHC -fdefer-type-errors #-}
 
 module Main where
@@ -9,25 +8,21 @@ import Test.Hspec.Expectations (expectationFailure)
 import Test.HUnit.Lang (performTestCase)
 import Test.ShouldNotTypecheck
 
-pattern TestSuccess = Nothing
-pattern TestFailure msg = Just (True, msg)
-pattern TestError msg = Just (False, msg)
-
 shouldFailAssertion :: IO () -> IO ()
 shouldFailAssertion value = do
   result <- performTestCase value
   case result of
-    TestSuccess -> expectationFailure "Did not throw an assertion error"
-    TestFailure _ -> return ()
-    TestError msg -> expectationFailure $ "Raised an error " ++ msg
+    Nothing           -> expectationFailure "Did not throw an assertion error"
+    Just (True,  _)   -> return ()
+    Just (False, msg) -> expectationFailure $ "Raised an error " ++ msg
 
 shouldThrowException :: Exception e => e -> IO () -> IO ()
 shouldThrowException exception value = do
   result <- performTestCase value
   case result of
-    TestSuccess -> expectationFailure "Did not throw exception: assertion succeeded"
-    TestFailure msg -> expectationFailure "Did not throw exception: assertion failed"
-    TestError msg -> case msg == show exception of
+    Nothing           -> expectationFailure "Did not throw exception: assertion succeeded"
+    Just (True,  _)   -> expectationFailure "Did not throw exception: assertion failed"
+    Just (False, msg) -> case msg == show exception of
       True -> return ()
       False -> expectationFailure "Incorrect exception propagated"
 


### PR DESCRIPTION
Since `-fdefer-type-errors` was introduced in GHC 7.6, and since I'd find this library useful on GHC 7.6, would you consider lowering the lower bound of `base` to `4.6`? (This means that you couldn't use `PatternSynonyms` in the test suite, but it's not too much of a change.)
