### PR TITLE
Add shouldNotTypecheckWith

### DIFF
--- a/src/Test/ShouldNotTypecheck.hs
+++ b/src/Test/ShouldNotTypecheck.hs
@@ -44,7 +44,7 @@ shouldNotTypecheckSatisfying predicate a = do
 
 {-|
    Like 'shouldNotTypecheck', but ensures that the given substring appears in
-   the reuslting type error.
+   the resulting type error.
 -}
 shouldNotTypecheckWith :: NFData a => String -> DeferredType(a) -> Assertion
 shouldNotTypecheckWith substring = shouldNotTypecheckSatisfying (isInfixOf substring)

--- a/src/Test/ShouldNotTypecheck.hs
+++ b/src/Test/ShouldNotTypecheck.hs
@@ -4,11 +4,12 @@
 #else
 #define TheExc ErrorCall
 #endif
-module Test.ShouldNotTypecheck (shouldNotTypecheck) where
+module Test.ShouldNotTypecheck (shouldNotTypecheck, shouldNotTypecheckWith) where
 
+import Data.Char
 import Control.DeepSeq (force, NFData)
 import Control.Exception (evaluate, try, throwIO, TheExc(..))
-import Data.List (isSuffixOf, isInfixOf)
+import Data.List (isSuffixOf, isInfixOf, isPrefixOf)
 import Test.HUnit.Lang (Assertion, assertFailure)
 
 {-|
@@ -23,13 +24,41 @@ shouldNotTypecheck :: NFData a => (() ~ () => a) -> Assertion
 #else
 shouldNotTypecheck :: NFData a => a -> Assertion
 #endif
+shouldNotTypecheck = shouldNotTypecheckWith ""
+
+{-|
+   Like 'shouldNotTypecheck', but ensures that the given substring appears in
+   the reuslting type error.
+-}
+#if __GLASGOW_HASKELL__ >= 800
+shouldNotTypecheckWith :: NFData a => String -> (() ~ () => a) -> Assertion
+#else
+shouldNotTypecheckWith :: NFData a => String -> a -> Assertion
+#endif
 -- The type for GHC-8.0.1 is a hack, see https://github.com/CRogers/should-not-typecheck/pull/6#issuecomment-211520177
-shouldNotTypecheck a = do
+shouldNotTypecheckWith substring a = do
   result <- try (evaluate $ force a)
   case result of
     Right _ -> assertFailure "Expected expression to not compile but it did compile"
     Left e@(TheExc msg) -> case isSuffixOf "(deferred type error)" msg of
       True -> case isInfixOf "No instance for" msg && isInfixOf "NFData" msg of
         True -> assertFailure $ "Make sure the expression has an NFData instance! See docs at https://github.com/CRogers/should-not-typecheck#nfdata-a-constraint. Full error:\n" ++ msg
-        False -> return ()
+        False -> case isInfixOf substring $ stripContext msg of
+           True -> return ()
+           False -> assertFailure ("type error did not contain \"" ++ substring ++ "\":\n" ++ msg)
       False -> throwIO e
+
+
+{-|
+  In GHC-8.0.0+, type errors contain a context which describes where the error
+  message was thrown from. This will include the call to 'shouldNotTypecheckWith',
+  which unless handled, would cause 'shouldNotTypecheckWith' to always succeed.
+  This function strips off the context from the error messages.
+-}
+stripContext :: String -> String
+#if __GLASGOW_HASKELL__ >= 800
+stripContext = unlines . takeWhile (not . isPrefixOf "• In the " . dropWhile isSpace) . lines
+#else
+stripContext = id
+#endif
+

--- a/src/Test/ShouldNotTypecheck.hs
+++ b/src/Test/ShouldNotTypecheck.hs
@@ -50,15 +50,14 @@ shouldNotTypecheckWith substring a = do
 
 
 {-|
-  In GHC-8.0.0+, type errors contain a context which describes where the error
-  message was thrown from. This will include the call to 'shouldNotTypecheckWith',
-  which unless handled, would cause 'shouldNotTypecheckWith' to always succeed.
-  This function strips off the context from the error messages.
+  In some versions of GHC, type errors contain a context which describes where
+  the error message was thrown from. This will include the call to
+  'shouldNotTypecheckWith', which unless handled, would cause
+  'shouldNotTypecheckWith' to always succeed.  This function strips off the
+  context from the error messages.
 -}
 stripContext :: String -> String
-#if __GLASGOW_HASKELL__ >= 800
-stripContext = unlines . takeWhile (not . isPrefixOf "• In the " . dropWhile isSpace) . lines
-#else
-stripContext = id
-#endif
+stripContext = unlines
+             . takeWhile (not . isPrefixOf "In the " . dropWhile (\x -> isSpace x || x == '•'))
+             . lines
 

--- a/test/ShouldNotTypecheckSpec.hs
+++ b/test/ShouldNotTypecheckSpec.hs
@@ -5,6 +5,7 @@ module Main where
 
 import Control.DeepSeq
 import Control.Exception
+import Data.List (isInfixOf)
 import GHC.Generics (Generic)
 import Test.Hspec
 import Test.Hspec.Expectations (expectationFailure)
@@ -87,11 +88,36 @@ main = hspec $ do
 
   describe "shouldNotTypecheckWith" $ do
      it "passes if the given string can be found in the error message" $ do
-       shouldNotTypecheckWith "Couldn't match expected type ‘Bool’ with actual type ‘()’"
+       shouldNotTypecheckWith "Couldn't match expected type"
          (not ())
 
      it "throws an exception if the given string is not found in the error message" $ do
        shouldFailAssertion $
          shouldNotTypecheckWith "foo"
            (not ())
+
+  describe "shouldNotTypecheckSatisfying" $ do
+     it "passes if the predicate passes" $ do
+       shouldNotTypecheckSatisfying
+         (\msg -> isInfixOf "Couldn't match expected type" msg
+               && isInfixOf "Bool" msg
+               && isInfixOf "with actual type" msg
+               && isInfixOf "()" msg
+         )
+         (not ())
+
+     it "passes if the predicate always passes" $ do
+       shouldNotTypecheckSatisfying (const True)
+         (not ())
+
+     it "throws an exception if predicate fails" $ do
+       shouldFailAssertion $
+         shouldNotTypecheckSatisfying ((== 5) . length)
+           (not ())
+
+     it "throws an exception if predicate always fails" $ do
+       shouldFailAssertion $
+         shouldNotTypecheckSatisfying (const False)
+           (not ())
+
 

--- a/test/ShouldNotTypecheckSpec.hs
+++ b/test/ShouldNotTypecheckSpec.hs
@@ -63,7 +63,7 @@ data NoNFDataInstance = NoNFDataInstance
 
 main :: IO ()
 main = hspec $ do
-  describe "shouldNotCompile" $ do
+  describe "shouldNotTypecheck" $ do
     it "should not throw an assertion error when an expression is ill typed" $ do
       shouldNotTypecheck ("foo" :: Int)
 
@@ -83,3 +83,15 @@ main = hspec $ do
 
     it "should warn if an expression had a type error due to lack of NFData instance" $ do
       shouldFailAssertion (shouldNotTypecheck NoNFDataInstance)
+
+
+  describe "shouldNotTypecheckWith" $ do
+     it "passes if the given string can be found in the error message" $ do
+       shouldNotTypecheckWith "Couldn't match expected type ‘Bool’ with actual type ‘()’"
+         (not ())
+
+     it "throws an exception if the given string is not found in the error message" $ do
+       shouldFailAssertion $
+         shouldNotTypecheckWith "foo"
+           (not ())
+


### PR DESCRIPTION
Like #11, but strips out the context on GHC-8.0.0+.